### PR TITLE
chore: Replace `commands.Bot` with `Luminara` wherever possible

### DIFF
--- a/handlers/error.py
+++ b/handlers/error.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 from loguru import logger
 
 from lib import exceptions
+from lib.client import Luminara
 from lib.const import CONST
 
 error_map: dict[type[Exception], str] = {
@@ -51,7 +52,7 @@ async def log_command_error(
 
 
 class ErrorHandler(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(self, bot: Luminara) -> None:
         self.bot = bot
 
     async def cog_load(self):
@@ -85,7 +86,7 @@ class ErrorHandler(commands.Cog):
     @commands.Cog.listener()
     async def on_command_error(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         error: commands.CommandError | commands.CheckFailure,
     ) -> None:
         if isinstance(error, commands.CommandNotFound | exceptions.Blacklisted):
@@ -107,5 +108,5 @@ class ErrorHandler(commands.Cog):
         await on_error(event, *args, **kwargs)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(ErrorHandler(bot))

--- a/handlers/event.py
+++ b/handlers/event.py
@@ -2,13 +2,14 @@ import discord
 from discord.ext import commands
 from loguru import logger
 
+from lib.client import Luminara
 from services.blacklist_service import BlacklistUserService
 from services.config_service import GuildConfig
 from ui.config import create_boost_embed, create_greet_embed
 
 
 class EventHandler(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
 
     @commands.Cog.listener()
@@ -76,7 +77,7 @@ class EventHandler(commands.Cog):
             )
 
     @commands.Cog.listener()
-    async def on_command_completion(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def on_command_completion(self, ctx: commands.Context[Luminara]) -> None:
         log_msg = f"{ctx.author.name} executed .{ctx.command.qualified_name if ctx.command else 'Unknown'}"
 
         if ctx.guild is not None:
@@ -94,5 +95,5 @@ class EventHandler(commands.Cog):
             logger.debug(f"{log_msg} in DMs")
 
 
-async def setup(bot: commands.Bot):
+async def setup(bot: Luminara):
     await bot.add_cog(EventHandler(bot))

--- a/lib/case_handler.py
+++ b/lib/case_handler.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from loguru import logger
 
+from lib.client import Luminara
 from lib.exceptions import LumiException
 from services.case_service import CaseService
 from services.modlog_service import ModLogService
@@ -12,7 +13,7 @@ modlog_service = ModLogService()
 
 
 async def create_case(
-    ctx: commands.Context[commands.Bot],
+    ctx: commands.Context[Luminara],
     target: discord.User,
     action_type: str,
     reason: str | None = None,
@@ -93,7 +94,7 @@ async def create_case(
 
 
 async def edit_case_modlog(
-    ctx: commands.Context[commands.Bot],
+    ctx: commands.Context[Luminara],
     guild_id: int,
     case_number: int,
     new_reason: str,

--- a/lib/format.py
+++ b/lib/format.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 from pytimeparse import parse  # type: ignore
 
 from lib import exceptions
+from lib.client import Luminara
 from lib.const import CONST
 from services.config_service import GuildConfig
 
@@ -76,7 +77,7 @@ def format_case_number(case_number: int) -> str:
     return f"{case_number:03d}" if case_number < 1000 else str(case_number)
 
 
-def get_prefix(ctx: commands.Context[commands.Bot]) -> str:
+def get_prefix(ctx: commands.Context[Luminara]) -> str:
     """
     Attempts to retrieve the prefix for the given guild context.
 
@@ -92,7 +93,7 @@ def get_prefix(ctx: commands.Context[commands.Bot]) -> str:
         return "."
 
 
-def get_invoked_name(ctx: commands.Context[commands.Bot]) -> str | None:
+def get_invoked_name(ctx: commands.Context[Luminara]) -> str | None:
     """
     Attempts to get the alias of the command used. If the user used a SlashCommand, return the command name.
 

--- a/modules/admin/admin.py
+++ b/modules/admin/admin.py
@@ -3,13 +3,14 @@ from discord.ext import commands
 
 import lib.format
 from db import database
+from lib.client import Luminara
 from lib.const import CONST
 from lib.format import shorten
 from ui.embeds import Builder
 
 
 class Sql(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.select_cmd.usage = lib.format.generate_usage(self.select_cmd)
         self.inject_cmd.usage = lib.format.generate_usage(self.inject_cmd)
@@ -18,7 +19,7 @@ class Sql(commands.Cog):
     @commands.is_owner()
     async def select_cmd(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         *,
         query: str,
     ) -> None:
@@ -27,7 +28,7 @@ class Sql(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         query : str
             The SQL query to execute.
@@ -65,7 +66,7 @@ class Sql(commands.Cog):
     @commands.is_owner()
     async def inject_cmd(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         *,
         query: str,
     ) -> None:
@@ -74,7 +75,7 @@ class Sql(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         query : str
             The SQL query to execute.
@@ -105,5 +106,5 @@ class Sql(commands.Cog):
         await ctx.send(embed=embed, ephemeral=True)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Sql(bot))

--- a/modules/admin/award.py
+++ b/modules/admin/award.py
@@ -2,13 +2,14 @@ import discord
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from services.currency_service import Currency
 from ui.embeds import Builder
 
 
 class Award(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.award_command.usage = lib.format.generate_usage(self.award_command)
 
@@ -16,7 +17,7 @@ class Award(commands.Cog):
     @commands.is_owner()
     async def award_command(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         user: discord.User,
         amount: int,
     ) -> None:
@@ -25,7 +26,7 @@ class Award(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         user : discord.User
             The user to award.
@@ -49,5 +50,5 @@ class Award(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Award(bot))

--- a/modules/admin/blacklist.py
+++ b/modules/admin/blacklist.py
@@ -2,13 +2,14 @@ import discord
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from services.blacklist_service import BlacklistUserService
 from ui.embeds import Builder
 
 
 class Blacklist(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.blacklist_command.usage = lib.format.generate_usage(self.blacklist_command)
 
@@ -16,7 +17,7 @@ class Blacklist(commands.Cog):
     @commands.is_owner()
     async def blacklist_command(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         user: discord.User,
         *,
         reason: str | None = None,
@@ -26,7 +27,7 @@ class Blacklist(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         user : discord.User
             The user to blacklist.
@@ -47,5 +48,5 @@ class Blacklist(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Blacklist(bot))

--- a/modules/admin/dev.py
+++ b/modules/admin/dev.py
@@ -35,7 +35,7 @@ class Dev(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         guild : discord.Guild | None, optional
             The guild to sync the tree to, by default None.
@@ -61,7 +61,7 @@ class Dev(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         guild : discord.Guild | None, optional
         """

--- a/modules/birthdays/birthday.py
+++ b/modules/birthdays/birthday.py
@@ -10,6 +10,7 @@ from discord.ext import commands, tasks
 from loguru import logger
 
 from lib.checks import birthdays_enabled
+from lib.client import Luminara
 from lib.const import CONST
 from services.birthday_service import BirthdayService
 from services.config_service import GuildConfig
@@ -19,7 +20,7 @@ from ui.embeds import Builder
 @app_commands.guild_only()
 @app_commands.default_permissions(manage_guild=True)
 class Birthday(commands.GroupCog, group_name="birthday"):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.daily_birthday_check.start()
 
@@ -207,5 +208,5 @@ class Birthday(commands.GroupCog, group_name="birthday"):
         await interaction.response.send_message(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Birthday(bot))

--- a/modules/config/config.py
+++ b/modules/config/config.py
@@ -3,6 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from services.config_service import GuildConfig
@@ -15,7 +16,7 @@ from ui.embeds import Builder
 @app_commands.guild_only()
 @app_commands.default_permissions(administrator=True)
 class Config(commands.GroupCog, group_name="config"):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
 
     birthdays = app_commands.Group(name="birthdays", description="Configure the birthdays module")
@@ -793,5 +794,5 @@ class Config(commands.GroupCog, group_name="config"):
         await interaction.response.send_message(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Config(bot))

--- a/modules/economy/balance.py
+++ b/modules/economy/balance.py
@@ -1,14 +1,15 @@
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from services.currency_service import Currency
 from ui.embeds import Builder
 
 
 class Balance(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.balance.usage = lib.format.generate_usage(self.balance)
 
     @commands.hybrid_command(
@@ -18,14 +19,14 @@ class Balance(commands.Cog):
     @commands.guild_only()
     async def balance(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
     ) -> None:
         """
         Check your current balance.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
 
@@ -46,5 +47,5 @@ class Balance(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Balance(bot))

--- a/modules/economy/blackjack.py
+++ b/modules/economy/blackjack.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 from loguru import logger
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from services.currency_service import Currency
@@ -21,8 +22,8 @@ Hand = list[Card]
 
 
 class Blackjack(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.blackjack.usage = lib.format.generate_usage(self.blackjack)
 
     @commands.hybrid_command(
@@ -32,7 +33,7 @@ class Blackjack(commands.Cog):
     @commands.guild_only()
     async def blackjack(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         bet: int,
     ) -> None:
         """
@@ -40,7 +41,7 @@ class Blackjack(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         bet : int
             The amount to bet.
@@ -64,7 +65,7 @@ class Blackjack(commands.Cog):
         finally:
             del ACTIVE_BLACKJACK_GAMES[ctx.author.id]
 
-    async def play_blackjack(self, ctx: commands.Context[commands.Bot], currency: Currency, bet: int) -> None:
+    async def play_blackjack(self, ctx: commands.Context[Luminara], currency: Currency, bet: int) -> None:
         deck = self.get_new_deck()
         player_hand, dealer_hand = self.initial_deal(deck)
         multiplier = CONST.BLACKJACK_MULTIPLIER
@@ -136,7 +137,7 @@ class Blackjack(commands.Cog):
 
     async def handle_game_end(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         response_message: discord.Message | None,
         currency: Currency,
         bet: int,
@@ -175,7 +176,7 @@ class Blackjack(commands.Cog):
 
     def create_game_embed(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         bet: int,
         player_hand: Hand,
         dealer_hand: Hand,
@@ -209,7 +210,7 @@ class Blackjack(commands.Cog):
 
     def create_end_game_embed(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         bet: int,
         player_value: int,
         dealer_value: int,
@@ -299,5 +300,5 @@ class Blackjack(commands.Cog):
         return value
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Blackjack(bot))

--- a/modules/economy/daily.py
+++ b/modules/economy/daily.py
@@ -5,6 +5,7 @@ from discord import Embed
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from services.currency_service import Currency
 from services.daily_service import Dailies
@@ -24,8 +25,8 @@ def seconds_until(hours: int, minutes: int) -> int:
 
 
 class Daily(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.daily.usage = lib.format.generate_usage(self.daily)
 
     @commands.hybrid_command(
@@ -35,14 +36,14 @@ class Daily(commands.Cog):
     @commands.guild_only()
     async def daily(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
     ) -> None:
         """
         Claim your daily reward.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         ctx_daily: Dailies = Dailies(ctx.author.id)
@@ -81,5 +82,5 @@ class Daily(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Daily(bot))

--- a/modules/economy/give.py
+++ b/modules/economy/give.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from services.currency_service import Currency
@@ -9,8 +10,8 @@ from ui.embeds import Builder
 
 
 class Give(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.give.usage = lib.format.generate_usage(self.give)
 
     @commands.hybrid_command(
@@ -19,7 +20,7 @@ class Give(commands.Cog):
     @commands.guild_only()
     async def give(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         user: discord.User,
         amount: int,
     ) -> None:
@@ -28,7 +29,7 @@ class Give(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         user : discord.User
             The user to give currency to.
@@ -66,5 +67,5 @@ class Give(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Give(bot))

--- a/modules/economy/slots.py
+++ b/modules/economy/slots.py
@@ -8,6 +8,7 @@ import discord
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from services.currency_service import Currency
@@ -17,8 +18,8 @@ est = ZoneInfo("US/Eastern")
 
 
 class Slots(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.slots.usage = lib.format.generate_usage(self.slots)
 
     @commands.hybrid_command(
@@ -28,7 +29,7 @@ class Slots(commands.Cog):
     @commands.guild_only()
     async def slots(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         bet: int,
     ) -> None:
         """
@@ -36,7 +37,7 @@ class Slots(commands.Cog):
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         bet : int
             The amount to bet.
@@ -134,7 +135,7 @@ class Slots(commands.Cog):
 
     def slots_spinning(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         spinning_icons_amount: int,
         bet: str,
         results: list[int],
@@ -179,7 +180,7 @@ class Slots(commands.Cog):
 
     def slots_finished(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         payout_type: str,
         bet: str,
         payout: str,
@@ -251,5 +252,5 @@ class Slots(commands.Cog):
         return embed
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Slots(bot))

--- a/modules/levels/leaderboard.py
+++ b/modules/levels/leaderboard.py
@@ -4,27 +4,28 @@ from discord import Embed, Guild, Member
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 from ui.views.leaderboard import LeaderboardCommandOptions, LeaderboardCommandView
 
 
 class Leaderboard(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.leaderboard.usage = lib.format.generate_usage(self.leaderboard)
 
     @commands.hybrid_command(
         name="leaderboard",
         aliases=["lb"],
     )
-    async def leaderboard(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def leaderboard(self, ctx: commands.Context[Luminara]) -> None:
         """
         Get the leaderboard for the server.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         guild: Guild | None = ctx.guild
@@ -48,5 +49,5 @@ class Leaderboard(commands.Cog):
         await ctx.send(embed=embed, view=view)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Leaderboard(bot))

--- a/modules/levels/level.py
+++ b/modules/levels/level.py
@@ -2,13 +2,14 @@ from discord import Embed
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from services.xp_service import XpService
 from ui.embeds import Builder
 
 
 class Level(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.level.usage = lib.format.generate_usage(self.level)
 
@@ -16,13 +17,13 @@ class Level(commands.Cog):
         name="level",
         aliases=["rank", "lvl", "xp"],
     )
-    async def level(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def level(self, ctx: commands.Context[Luminara]) -> None:
         """
         Get the level of the user.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         if not ctx.guild:
@@ -52,5 +53,5 @@ class Level(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Level(bot))

--- a/modules/misc/avatar.py
+++ b/modules/misc/avatar.py
@@ -6,6 +6,7 @@ from discord import File
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 
 
 async def create_avatar_file(url: str) -> File:
@@ -32,7 +33,7 @@ async def create_avatar_file(url: str) -> File:
 
 
 class Avatar(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.avatar.usage = lib.format.generate_usage(self.avatar)
 
@@ -42,7 +43,7 @@ class Avatar(commands.Cog):
     )
     async def avatar(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         member: discord.Member | None = None,
     ) -> None:
         """
@@ -69,5 +70,5 @@ class Avatar(commands.Cog):
             await ctx.send(content="member has no avatar.")
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Avatar(bot))

--- a/modules/misc/backup.py
+++ b/modules/misc/backup.py
@@ -9,6 +9,7 @@ from discord.ext import commands, tasks
 from dropbox.files import FileMetadata  # type: ignore
 from loguru import logger
 
+from lib.client import Luminara
 from lib.const import CONST
 
 # Initialize Dropbox client if instance is "main"
@@ -77,8 +78,8 @@ async def backup() -> None:
 
 
 class Backup(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.do_backup.start()
 
     @tasks.loop(hours=1)
@@ -91,5 +92,5 @@ class Backup(commands.Cog):
         await asyncio.sleep(30)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Backup(bot))

--- a/modules/misc/info.py
+++ b/modules/misc/info.py
@@ -6,19 +6,20 @@ import psutil
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 
 
 class Info(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.info.usage = lib.format.generate_usage(self.info)
 
     @commands.hybrid_command(
         name="info",
     )
-    async def info(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def info(self, ctx: commands.Context[Luminara]) -> None:
         memory_usage_in_mb: float = psutil.Process().memory_info().rss / (1024 * 1024)
         # total_rows: str = Currency.format(BlackJackStats.get_total_rows_count())
 
@@ -46,5 +47,5 @@ class Info(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Info(bot))

--- a/modules/misc/introduction.py
+++ b/modules/misc/introduction.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 from ui.views.introduction import (
@@ -11,18 +12,18 @@ from ui.views.introduction import (
 
 
 class Introduction(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.introduction.usage = lib.format.generate_usage(self.introduction)
 
     @commands.hybrid_command(name="introduction", aliases=["intro"])
-    async def introduction(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def introduction(self, ctx: commands.Context[Luminara]) -> None:
         """
         Introduction command.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         guild: discord.Guild | None = self.bot.get_guild(
@@ -188,5 +189,5 @@ class Introduction(commands.Cog):
                 )
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Introduction(bot))

--- a/modules/misc/invite.py
+++ b/modules/misc/invite.py
@@ -1,24 +1,25 @@
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 from ui.views.invite import InviteButton
 
 
 class Invite(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.invite.usage = lib.format.generate_usage(self.invite)
 
     @commands.hybrid_command(name="invite", aliases=["inv"])
-    async def invite(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def invite(self, ctx: commands.Context[Luminara]) -> None:
         """
         Invite command.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         await ctx.send(
@@ -32,5 +33,5 @@ class Invite(commands.Cog):
         )
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Invite(bot))

--- a/modules/misc/ping.py
+++ b/modules/misc/ping.py
@@ -1,23 +1,24 @@
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 
 
 class Ping(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.ping.usage = lib.format.generate_usage(self.ping)
 
     @commands.hybrid_command(name="ping")
-    async def ping(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def ping(self, ctx: commands.Context[Luminara]) -> None:
         """
         Show Luminara's latency.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         embed = Builder.create_embed(
@@ -33,5 +34,5 @@ class Ping(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Ping(bot))

--- a/modules/misc/uptime.py
+++ b/modules/misc/uptime.py
@@ -5,24 +5,25 @@ from discord import Embed
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 
 
 class Uptime(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot: commands.Bot = bot
+    def __init__(self, bot: Luminara) -> None:
+        self.bot: Luminara = bot
         self.start_time: datetime = discord.utils.utcnow()
         self.uptime.usage = lib.format.generate_usage(self.uptime)
 
     @commands.hybrid_command(name="uptime")
-    async def uptime(self, ctx: commands.Context[commands.Bot]) -> None:
+    async def uptime(self, ctx: commands.Context[Luminara]) -> None:
         """
         Uptime command.
 
         Parameters
         ----------
-        ctx : commands.Context[commands.Bot]
+        ctx : commands.Context[Luminara]
             The context of the command.
         """
         unix_timestamp: int = int(self.start_time.timestamp())
@@ -39,5 +40,5 @@ class Uptime(commands.Cog):
         await ctx.send(embed=embed)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Uptime(bot))

--- a/modules/misc/xkcd.py
+++ b/modules/misc/xkcd.py
@@ -2,6 +2,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 from wrappers.xkcd import Client, HttpError
@@ -47,7 +48,7 @@ async def print_comic(
 
 
 class Xkcd(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
 
     xkcd = app_commands.Group(name="xkcd", description="Get the latest xkcd comic")
@@ -91,5 +92,5 @@ class Xkcd(commands.Cog):
         await print_comic(interaction, number=comic_id)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Xkcd(bot))

--- a/modules/moderation/ban.py
+++ b/modules/moderation/ban.py
@@ -8,12 +8,13 @@ from discord.ext import commands
 import lib.format
 from lib.actionable import async_actionable
 from lib.case_handler import create_case
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 
 
 class Ban(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.ban.usage = lib.format.generate_usage(self.ban)
         self.unban.usage = lib.format.generate_usage(self.unban)
@@ -24,7 +25,7 @@ class Ban(commands.Cog):
     @commands.guild_only()
     async def ban(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.Member | discord.User,
         *,
         reason: str | None = None,
@@ -93,7 +94,7 @@ class Ban(commands.Cog):
     @commands.guild_only()
     async def unban(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.User,
         *,
         reason: str | None = None,
@@ -145,5 +146,5 @@ class Ban(commands.Cog):
             )
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Ban(bot))

--- a/modules/moderation/cases.py
+++ b/modules/moderation/cases.py
@@ -6,6 +6,7 @@ from reactionmenu import ViewButton, ViewMenu
 
 import lib.format
 from lib.case_handler import edit_case_modlog
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from lib.format import format_case_number
@@ -19,7 +20,7 @@ from ui.embeds import Builder
 case_service = CaseService()
 
 
-def create_no_cases_embed(ctx: commands.Context[commands.Bot], author_text: str, description: str) -> discord.Embed:
+def create_no_cases_embed(ctx: commands.Context[Luminara], author_text: str, description: str) -> discord.Embed:
     return Builder.create_embed(
         theme="info",
         user_name=ctx.author.name,
@@ -28,7 +29,7 @@ def create_no_cases_embed(ctx: commands.Context[commands.Bot], author_text: str,
     )
 
 
-def create_case_view_menu(ctx: commands.Context[commands.Bot]) -> ViewMenu:
+def create_case_view_menu(ctx: commands.Context[Luminara]) -> ViewMenu:
     menu = ViewMenu(ctx, menu_type=ViewMenu.TypeEmbed, all_can_click=True, delete_on_timeout=True)
 
     buttons = [
@@ -45,7 +46,7 @@ def create_case_view_menu(ctx: commands.Context[commands.Bot]) -> ViewMenu:
 
 
 class Cases(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.view_case_by_number.usage = lib.format.generate_usage(self.view_case_by_number)
         self.view_all_cases_in_guild.usage = lib.format.generate_usage(self.view_all_cases_in_guild)
@@ -57,7 +58,7 @@ class Cases(commands.Cog):
     @commands.guild_only()
     async def view_case_by_number(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         case_number: int | None = None,
     ) -> None:
         """
@@ -101,14 +102,14 @@ class Cases(commands.Cog):
     @commands.guild_only()
     async def view_all_cases_in_guild(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
     ) -> None:
         """
         View all cases in the guild.
 
         Parameters
         ----------
-        ctx: commands.Context[commands.Bot]
+        ctx: commands.Context[Luminara]
             The context of the command.
         """
         if not ctx.guild:
@@ -144,7 +145,7 @@ class Cases(commands.Cog):
     @commands.guild_only()
     async def view_all_cases_by_mod(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         moderator: discord.Member,
     ) -> None:
         """
@@ -188,7 +189,7 @@ class Cases(commands.Cog):
     @commands.guild_only()
     async def edit_case_reason(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         case_number: int,
         *,
         new_reason: str,
@@ -232,5 +233,5 @@ class Cases(commands.Cog):
         await update_tasks()
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Cases(bot))

--- a/modules/moderation/kick.py
+++ b/modules/moderation/kick.py
@@ -7,12 +7,13 @@ from discord.ext import commands
 import lib.format
 from lib.actionable import async_actionable
 from lib.case_handler import create_case
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 
 
 class Kick(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.kick.usage = lib.format.generate_usage(self.kick)
 
@@ -22,7 +23,7 @@ class Kick(commands.Cog):
     @commands.guild_only()
     async def kick(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.Member,
         *,
         reason: str | None = None,
@@ -86,5 +87,5 @@ class Kick(commands.Cog):
         await asyncio.gather(respond_task, create_case_task, return_exceptions=True)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Kick(bot))

--- a/modules/moderation/slowmode.py
+++ b/modules/moderation/slowmode.py
@@ -5,19 +5,20 @@ from discord import app_commands
 from discord.ext import commands
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from lib.format import format_duration_to_seconds
 
 
 class Slowmode(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.slowmode.usage = lib.format.generate_usage(self.slowmode)
 
     async def _set_slowmode(
         self,
-        ctx: commands.Context[commands.Bot] | discord.Interaction,
+        ctx: commands.Context[Luminara] | discord.Interaction,
         channel: discord.TextChannel,
         duration: str | None,
     ) -> None:
@@ -46,7 +47,7 @@ class Slowmode(commands.Cog):
 
     async def _send_response(
         self,
-        ctx: commands.Context[commands.Bot] | discord.Interaction,
+        ctx: commands.Context[Luminara] | discord.Interaction,
         content: str,
         ephemeral: bool = False,
     ) -> None:
@@ -64,7 +65,7 @@ class Slowmode(commands.Cog):
     @commands.guild_only()
     async def slowmode(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         arg1: str | None = None,
         arg2: str | None = None,
     ) -> None:
@@ -119,5 +120,5 @@ class Slowmode(commands.Cog):
         await self._set_slowmode(interaction, channel, duration)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Slowmode(bot))

--- a/modules/moderation/softban.py
+++ b/modules/moderation/softban.py
@@ -7,12 +7,13 @@ from discord.ext import commands
 import lib.format
 from lib.actionable import async_actionable
 from lib.case_handler import create_case
+from lib.client import Luminara
 from lib.const import CONST
 from ui.embeds import Builder
 
 
 class Softban(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.softban.usage = lib.format.generate_usage(self.softban)
 
@@ -22,7 +23,7 @@ class Softban(commands.Cog):
     @commands.guild_only()
     async def softban(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.Member,
         *,
         reason: str | None = None,
@@ -94,5 +95,5 @@ class Softban(commands.Cog):
         await asyncio.gather(respond_task, create_case_task, return_exceptions=True)
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Softban(bot))

--- a/modules/moderation/timeout.py
+++ b/modules/moderation/timeout.py
@@ -8,13 +8,14 @@ from discord.ext import commands
 import lib.format
 from lib.actionable import async_actionable
 from lib.case_handler import create_case
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from ui.embeds import Builder
 
 
 class Timeout(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.timeout.usage = lib.format.generate_usage(self.timeout)
         self.untimeout.usage = lib.format.generate_usage(self.untimeout)
@@ -25,7 +26,7 @@ class Timeout(commands.Cog):
     @commands.guild_only()
     async def timeout(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.Member,
         duration: str,
         reason: str | None = None,
@@ -106,7 +107,7 @@ class Timeout(commands.Cog):
     @commands.guild_only()
     async def untimeout(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.Member,
         reason: str | None = None,
     ) -> None:
@@ -159,5 +160,5 @@ class Timeout(commands.Cog):
             )
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Timeout(bot))

--- a/modules/moderation/warn.py
+++ b/modules/moderation/warn.py
@@ -7,13 +7,14 @@ from discord.ext import commands
 import lib.format
 from lib.actionable import async_actionable
 from lib.case_handler import create_case
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from ui.embeds import Builder
 
 
 class Warn(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
         self.warn.usage = lib.format.generate_usage(self.warn)
 
@@ -22,7 +23,7 @@ class Warn(commands.Cog):
     @commands.guild_only()
     async def warn(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         target: discord.Member,
         *,
         reason: str | None = None,
@@ -78,5 +79,5 @@ class Warn(commands.Cog):
         )
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Warn(bot))

--- a/modules/triggers/triggers.py
+++ b/modules/triggers/triggers.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 from reactionmenu import ViewButton, ViewMenu
 
 import lib.format
+from lib.client import Luminara
 from lib.const import CONST
 from lib.exceptions import LumiException
 from services.reactions_service import CustomReactionsService
@@ -15,7 +16,7 @@ from ui.embeds import Builder
 @app_commands.guild_only()
 @app_commands.default_permissions(manage_guild=True)
 class Triggers(commands.GroupCog, group_name="trigger"):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Luminara):
         self.bot = bot
 
     add = app_commands.Group(
@@ -282,5 +283,5 @@ class Triggers(commands.GroupCog, group_name="trigger"):
         await menu.start()
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Luminara) -> None:
     await bot.add_cog(Triggers(bot))

--- a/settings.yaml
+++ b/settings.yaml
@@ -88,7 +88,7 @@ info:
   title: Luminara
   author: wlinator
   license: GNU General Public License v3.0
-  version: "3.0.0-alpha"
+  version: "3.0.1"
   repository_url: https://git.wlinator.org/Luminara/Lumi
   invite_url: https://discord.com/oauth2/authorize?client_id=1038050427272429588&permissions=8&scope=bot
 

--- a/ui/cases.py
+++ b/ui/cases.py
@@ -4,13 +4,14 @@ from typing import Any
 import discord
 from discord.ext import commands
 
+from lib.client import Luminara
 from lib.const import CONST
 from lib.format import format_case_number, format_seconds_to_duration_string
 from ui.embeds import Builder
 
 
 def create_case_embed(
-    ctx: commands.Context[commands.Bot],
+    ctx: commands.Context[Luminara],
     target: discord.User,
     case_number: int,
     action_type: str,
@@ -76,7 +77,7 @@ def create_case_embed(
 
 
 def create_case_list_embed(
-    ctx: commands.Context[commands.Bot],
+    ctx: commands.Context[Luminara],
     cases: list[dict[str, Any]],
     author_text: str,
 ) -> discord.Embed:

--- a/ui/views/blackjack.py
+++ b/ui/views/blackjack.py
@@ -2,13 +2,14 @@ import discord
 from discord.ext import commands
 from discord.ui import Button, View
 
+from lib.client import Luminara
 from lib.const import CONST
 
 
 class BlackJackButtons(View):
-    def __init__(self, ctx: commands.Context[commands.Bot]) -> None:
+    def __init__(self, ctx: commands.Context[Luminara]) -> None:
         super().__init__(timeout=180)
-        self.ctx: commands.Context[commands.Bot] = ctx
+        self.ctx: commands.Context[Luminara] = ctx
         self.clickedHit: bool = False
         self.clickedStand: bool = False
         self.clickedDoubleDown: bool = False

--- a/ui/views/introduction.py
+++ b/ui/views/introduction.py
@@ -2,11 +2,13 @@ import discord
 from discord.ext import commands
 from discord.ui import Button, View
 
+from lib.client import Luminara
+
 
 class IntroductionStartButtons(View):
-    def __init__(self, ctx: commands.Context[commands.Bot]) -> None:
+    def __init__(self, ctx: commands.Context[Luminara]) -> None:
         super().__init__(timeout=60)
-        self.ctx: commands.Context[commands.Bot] = ctx
+        self.ctx: commands.Context[Luminara] = ctx
         self.clicked_start: bool = False
         self.clicked_stop: bool = False
         self.message: discord.Message | None = None
@@ -40,9 +42,9 @@ class IntroductionStartButtons(View):
 
 
 class IntroductionFinishButtons(View):
-    def __init__(self, ctx: commands.Context[commands.Bot]) -> None:
+    def __init__(self, ctx: commands.Context[Luminara]) -> None:
         super().__init__(timeout=60)
-        self.ctx: commands.Context[commands.Bot] = ctx
+        self.ctx: commands.Context[Luminara] = ctx
         self.clicked_confirm: bool = False
         self.message: discord.Message | None = None
 

--- a/ui/views/leaderboard.py
+++ b/ui/views/leaderboard.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import discord
 from discord.ext import commands
 
+from lib.client import Luminara
 from lib.const import CONST
 from services.currency_service import Currency
 from services.daily_service import Dailies
@@ -58,12 +59,12 @@ class LeaderboardCommandView(discord.ui.View):
     what kind of leaderboard to show.
     """
 
-    ctx: commands.Context[commands.Bot]
+    ctx: commands.Context[Luminara]
     options: LeaderboardCommandOptions
 
     def __init__(
         self,
-        ctx: commands.Context[commands.Bot],
+        ctx: commands.Context[Luminara],
         options: LeaderboardCommandOptions,
     ) -> None:
         super().__init__(timeout=180)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the bot client type from `commands.Bot` to `Luminara` throughout the codebase to ensure consistency and potentially leverage new features or improvements associated with the `Luminara` client.

Enhancements:
- Replace the use of `commands.Bot` with `Luminara` across multiple modules to standardize the bot client type.

<!-- Generated by sourcery-ai[bot]: end summary -->